### PR TITLE
Add notifications mute toggle

### DIFF
--- a/Technical-Analysis/perp-scanner/perp.py
+++ b/Technical-Analysis/perp-scanner/perp.py
@@ -1,5 +1,6 @@
 import sys
 import time
+import workers
 from workers import SpotWorker, FuturesWorker
 
 from PyQt5.QtCore import QThread, Qt
@@ -40,6 +41,12 @@ class MainWindow(QMainWindow):
         self.setCentralWidget(central)
         main_layout = QVBoxLayout()
         central.setLayout(main_layout)
+
+        # Button to mute/unmute system notifications
+        self.mute_button = QPushButton("Mute Notifications")
+        self.mute_button.setCheckable(True)
+        self.mute_button.toggled.connect(self.toggle_mute)
+        main_layout.addWidget(self.mute_button)
 
         # Tabs
         self.tabs = QTabWidget()
@@ -162,6 +169,15 @@ class MainWindow(QMainWindow):
         SCAN_INTERVAL_SEC = self.fut_interval_spin.value()
         self.log(f"Futures interval changed to {SCAN_INTERVAL_SEC} seconds")
         self.fut_status_label.setText(f"Status: Interval set to {SCAN_INTERVAL_SEC}s")
+
+    def toggle_mute(self, checked: bool):
+        workers.MUTE_NOTIFICATIONS = checked
+        if checked:
+            self.mute_button.setText("Unmute Notifications")
+            self.log("Notifications muted")
+        else:
+            self.mute_button.setText("Mute Notifications")
+            self.log("Notifications unmuted")
 
     def on_spot_started(self):
         self.spot_status_label.setText("Status: Loading...")

--- a/Technical-Analysis/perp-scanner/workers.py
+++ b/Technical-Analysis/perp-scanner/workers.py
@@ -4,6 +4,9 @@ from PyQt5.QtCore import QObject, pyqtSignal
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from plyer import notification
 
+# Global flag to disable desktop notifications
+MUTE_NOTIFICATIONS = False
+
 # ─── CONFIGURATION ────────────────────────────────────────────────────────────
 SPOT_API_BASE       = "https://api.kraken.com/0/public"
 FUTURES_API_BASE    = "https://futures.kraken.com/derivatives/api/v3"
@@ -127,11 +130,12 @@ class SpotWorker(QObject):
                         vol_str    = f"{vol*price:,.1f}"
                         price_str  = f"{price:.2f}"
                         table_rows.append((symbol, init_str, prev_str, now_str, vol_str, price_str, prev_high, prev_low))
-                        notification.notify(
-                            title="New Spot Alert",
-                            message=f"{symbol} changed by {new_pct:.2f}% with volume ${vol*price:,.1f}",
-                            timeout=5
-                        )
+                        if not MUTE_NOTIFICATIONS:
+                            notification.notify(
+                                title="New Spot Alert",
+                                message=f"{symbol} changed by {new_pct:.2f}% with volume ${vol*price:,.1f}",
+                                timeout=5
+                            )
                         self.log_message.emit(f"Spot coin added: {symbol} at {new_pct:.2f}%")
                 else:
                     initial = record['initial']
@@ -262,11 +266,12 @@ class FuturesWorker(QObject):
                     vol_str    = f"{vol*price:,.1f}"
                     price_str  = f"{price:.2f}"
                     table_rows.append((symbol, init_str, prev_str, now_str, vol_str, price_str, prev_high, prev_low))
-                    notification.notify(
-                        title="New Futures Alert",
-                        message=f"{symbol} at {new_pct:.2f}% (Vol: ${vol*price:,.1f})",
-                        timeout=5,
-                    )
+                    if not MUTE_NOTIFICATIONS:
+                        notification.notify(
+                            title="New Futures Alert",
+                            message=f"{symbol} at {new_pct:.2f}% (Vol: ${vol*price:,.1f})",
+                            timeout=5,
+                        )
                     self.log_message.emit(f"Futures added: {symbol} at {new_pct:.2f}%")
                 else:
                     initial = record['initial']


### PR DESCRIPTION
## Summary
- add global `MUTE_NOTIFICATIONS` flag in `workers.py`
- check mute flag before raising plyer notifications
- expose mute toggle button in `perp.py` GUI and provide a handler to update the flag

## Testing
- `python -m py_compile Technical-Analysis/perp-scanner/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6850192f5bd483239c67c1852d6647f5