### PR TITLE
Chart API integration

### DIFF
--- a/Technical-Analysis/perp-scanner/utils/chart_api.py
+++ b/Technical-Analysis/perp-scanner/utils/chart_api.py
@@ -1,0 +1,32 @@
+from dotenv import load_dotenv
+import os
+import requests
+
+load_dotenv()
+API_KEY = os.getenv("CHART_IMG_API_KEY")
+
+URL = "https://api.chart-img.com/v2/tradingview/advanced-chart"
+HEADERS = {
+    "x-api-key": API_KEY if API_KEY else "",
+    "Content-Type": "application/json",
+}
+
+COMMON = {
+    "width": 800,
+    "height": 600,
+    "theme": "Dark",
+    "timezone": "Etc/UTC",
+    "studies": [
+        {"name": "Volume", "forceOverlay": True},
+        {"name": "Relative Strength Index"},
+    ],
+}
+
+def fetch_chart(symbol: str, interval: str) -> bytes:
+    """Return raw PNG bytes for the given symbol and interval."""
+    if not API_KEY:
+        raise RuntimeError("CHART_IMG_API_KEY not set")
+    payload = {**COMMON, "symbol": symbol, "interval": interval}
+    resp = requests.post(URL, headers=HEADERS, json=payload, timeout=15)
+    resp.raise_for_status()
+    return resp.content


### PR DESCRIPTION
## Summary
- integrate Chart API client for TradingView images
- display per-pair charts in RSI popup window

## Testing
- `python3 -m py_compile Technical-Analysis/perp-scanner/main.py Technical-Analysis/perp-scanner/utils/chart_api.py`

------
https://chatgpt.com/codex/tasks/task_e_685e7b281d388323aa0a5dd91d6a29b4